### PR TITLE
Finished standard/upload types user story

### DIFF
--- a/portal/assign.py
+++ b/portal/assign.py
@@ -125,6 +125,13 @@ def assign_edit(course_id, assign_id, sessions_id):
         points = request.form['edit_points']
         description = request.form['edit_desc']
         due_date = request.form['edit_date']
+
+        if request.form['edit_type'] == 'upload':
+            type = 'upload'
+        else:
+            # Anything other than upload will default to standard
+            type = 'standard'
+
         error = None
 
         try:

--- a/portal/assign.py
+++ b/portal/assign.py
@@ -141,7 +141,7 @@ def assign_edit(course_id, assign_id, sessions_id):
         try:
             datetime.datetime.strptime(due_date, '%Y-%m-%dT%H:%M')
         except ValueError:
-            error = 'Due Date only allows time data, check your values. Please format the time as such using military time. Year-Month-Day Hour:Minute ex. 2020-06-22 19:10'
+            error = 'Please format date & time as "Year-Month-Day Hour:Minute" (ex. 2020-06-22 19:10)'
 
         with db.get_db() as con:
             with con.cursor() as cur:

--- a/portal/assign.py
+++ b/portal/assign.py
@@ -30,6 +30,13 @@ def assign_create(sessions_id, course_id):
         points = request.form['points']
         description = request.form['description']
         due_date = request.form['due_date']
+
+        if request.form['type'] == 'upload':
+            type = 'upload'
+        else:
+            # Anything other than upload will default to standard
+            type = 'standard'
+
         error = None
 
         try:
@@ -50,10 +57,9 @@ def assign_create(sessions_id, course_id):
 
                 if error is None:
                     now = datetime.datetime.utcnow()
-                    cur.execute("""INSERT INTO assignments (sessions_id, assign_name, description, points, due_time)
-                        VALUES (%s, %s, %s, %s, %s)
-                    """,
-                    (sessions_id, name, description, points, due_date, )
+                    cur.execute("""INSERT INTO assignments (sessions_id, assign_name, description, points, due_time, type)
+                        VALUES (%s, %s, %s, %s, %s, %s)""",
+                        (sessions_id, name, description, points, due_date, type,)
                     )
                     con.commit()
 
@@ -160,7 +166,7 @@ def get_assignment(assign_id):
     with db.get_db() as con:
         with con.cursor() as cur:
             cur.execute(
-                'SELECT id, assign_name, description, points, sessions_id, due_time'
+                'SELECT *'
                 ' FROM assignments WHERE id = %s',
                 (assign_id, )
             )

--- a/portal/schema.sql
+++ b/portal/schema.sql
@@ -57,7 +57,8 @@ CREATE TABLE assignments (
   assign_name text NOT NULL,
   description text NOT NULL,
   points integer NOT NULL,
-  due_time timestamp NOT NULL
+  due_time timestamp NOT NULL,
+  type varchar(10)
 );
 
 -- Rosters

--- a/portal/static/styles.css
+++ b/portal/static/styles.css
@@ -368,6 +368,7 @@ p.flash {
   box-shadow: 2px 2px 5px black;
   color: red;
   display: flex;
+  font-size: 16px;
   font-weight: bold;
   height: 3rem;
   justify-content: center;

--- a/portal/static/styles.css
+++ b/portal/static/styles.css
@@ -127,11 +127,22 @@ a {
 a:hover {
   text-decoration: underline;
   color: #8B1E41;
-
 }
 
 a.back:hover {
   color: white;
+}
+
+a.submit_assignment {
+  border: 2px solid #8B1E41;
+  border-radius: 2px;
+  box-shadow: 2px 2px 2px black;
+  display: inline-block;
+  margin-bottom: 1rem;
+}
+
+a.submit_assignment:hover {
+  box-shadow: inset 1px 1px 2px black;
 }
 
 section {
@@ -197,6 +208,10 @@ ul.submissions li {
 
 ul.submissions li:nth-child(2n) {
   background-color: lightgrey;
+}
+
+table {
+  margin-bottom: 1rem;
 }
 
 table, th, td {
@@ -291,9 +306,12 @@ input, textarea {
 }
 
 
-form.session label, form.assign label {
+form.session label {
   border-bottom: 2px solid white;
+}
 
+form.assign label {
+  text-decoration: underline;
 }
 
 label {
@@ -330,6 +348,10 @@ label.grade input {
   margin: 0;
 }
 
+select {
+  display: block;
+  margin-top: .5rem;
+}
 
 @media (min-width: 760px) {
   form {

--- a/portal/templates/assigns/assign_create.html
+++ b/portal/templates/assigns/assign_create.html
@@ -39,6 +39,13 @@
       <input type="datetime-local" name="due_date">
     </label>
 
+    <label for="type">Type
+      <select name="type">
+        <option value="standard">Standard</option>
+        <option value="upload">Upload</option>
+      </select>
+    </label>
+
     <input type="submit" name="assign_creation_button" value="Save">
 
   </form>

--- a/portal/templates/assigns/assign_edit.html
+++ b/portal/templates/assigns/assign_edit.html
@@ -64,9 +64,9 @@
 
         <select name="edit_type">
 
-          <option value="standard">Standard</option>
+          <option value="standard" {% if assignment['type'] == 'standard' %}selected{% endif %}>Standard</option>
 
-          <option value="upload">Upload</option>
+          <option value="upload" {% if assignment['type'] == 'upload' %}selected{% endif %}>Upload</option>
 
         </select>
 

--- a/portal/templates/assigns/assign_edit.html
+++ b/portal/templates/assigns/assign_edit.html
@@ -58,6 +58,20 @@
 
       </li>
 
+      <li>
+
+        <label for="edit_type">Type</label>
+
+        <select name="edit_type">
+
+          <option value="standard">Standard</option>
+
+          <option value="upload">Upload</option>
+
+        </select>
+
+      </li>
+
     </ul>
 
     <input type="submit" name="assignmentEditSumbit" value="Save">

--- a/portal/templates/student_views/assignment_details.html
+++ b/portal/templates/student_views/assignment_details.html
@@ -35,7 +35,7 @@
 
 {% if assignment['type'] == 'upload' %}
 
-  <a href="#">Submit Assignment</a>
+  <a class="submit_assignment" href="#">Submit Assignment</a>
 
 {% endif %}
 

--- a/portal/templates/student_views/assignment_details.html
+++ b/portal/templates/student_views/assignment_details.html
@@ -33,5 +33,11 @@
 
 </table>
 
+{% if assignment['type'] == 'upload' %}
+
+  <a href="#">Submit Assignment</a>
+
+{% endif %}
+
 
 {% endblock %}

--- a/tests/test_assign.py
+++ b/tests/test_assign.py
@@ -124,7 +124,8 @@ def test_assign_edit(client):
     assert b'Points' in response.data
     #editing the page with request
     response_2 = client.post('/course/180/session/2/assignment/Edit/1/', data={'edit_name': 'first portal creation',
-     'edit_desc': 'first test', 'edit_points': 90, 'edit_date': '2020-06-22T19:10'},follow_redirects=True)
+     'edit_desc': 'first test', 'edit_points': 90, 'edit_date': '2020-06-22T19:10',
+     'edit_type': 'standard'}, follow_redirects=True)
     assert b'Assignments for CSET-180-A' in response_2.data
     assert b'first portal creation' in response_2.data
     #logout
@@ -146,7 +147,9 @@ def test_edit_errors(client, name, description, points, edit_date, error):
     assert b'Logged in' in rv.data
 
     response = client.post('/course/180/session/2/assignment/Edit/1/', data={'edit_name': name,
-     'edit_desc': description, 'edit_points': points, 'edit_date': edit_date },follow_redirects = True)
+     'edit_desc': description, 'edit_points': points, 'edit_date': edit_date,
+     'edit_type': 'standard'}, follow_redirects = True)
+
     assert error in response.data
 
     rv = logout(client)

--- a/tests/test_assign.py
+++ b/tests/test_assign.py
@@ -125,7 +125,7 @@ def test_assign_edit(client):
     #editing the page with request
     response_2 = client.post('/course/180/session/2/assignment/Edit/1/', data={'edit_name': 'first portal creation',
      'edit_desc': 'first test', 'edit_points': 90, 'edit_date': '2020-06-22T19:10',
-     'edit_type': 'standard'}, follow_redirects=True)
+     'edit_type': 'upload'}, follow_redirects=True)
     assert b'Assignments for CSET-180-A' in response_2.data
     assert b'first portal creation' in response_2.data
     #logout

--- a/tests/test_assign.py
+++ b/tests/test_assign.py
@@ -24,7 +24,8 @@ def test_assign_create(client):
     #make post request to test functionality of test created
     #test redirection to assign manage
     response_2 = client.post('/course/180/session/2/assignment/create/', data={'name': 'portal creation',
-     'description': 'testing_description', 'points': 100, 'due_date': '2020-06-22T19:10'}, follow_redirects=True)
+     'description': 'testing_description', 'points': 100, 'due_date': '2020-06-22T19:10',
+     'type': 'standard'}, follow_redirects=True)
     #in assign manage data make sure assign manage is there
     assert b'Assignments for CSET-180-A' in response_2.data
     assert b'portal creation' in response_2.data
@@ -48,13 +49,44 @@ def test_create_errors(client, name, description, points, due_date, error):
 
 
     response = client.post('/course/180/session/2/assignment/create/', data={'name': name,
-     'description': description, 'points': points, 'due_date': due_date })
+     'description': description, 'points': points, 'due_date': due_date , 'type': 'standard'})
 
     assert error in response.data
 
     rv = logout(client)
     assert b'TSCT Portal Login' in rv.data
 
+
+@pytest.mark.parametrize(('type'), (
+    ('standard'),
+    ('sadf8ewfhc'),
+    ('upload')
+))
+def test_types(client, type):
+
+    with client:
+        # Log in as the teacher to create the assignment
+        login(client, 'teacher2@stevenscollege.edu', 'PASSWORD')
+
+        client.post('/course/216/session/1/assignment/create/', data={
+            'name': 'test',
+            'description': 'this is a test assignment',
+            'points': 100,
+            'due_date': '2020-05-29T12:00',
+            'type': type
+        })
+        logout(client)
+
+        # Log in as the student to check for a submit button
+        login(client, 'student2@stevenscollege.edu', '123456789')
+
+        response = client.get('/course/216/session/1/assignment_details/3')
+        # If the assignment is upload type, there should be a submit button
+        # on the page.  If not, then there shouldn't be
+        if type == 'upload':
+            assert b'Submit' in response.data
+        else:
+            assert b'Submit' not in response.data
 
 
 def test_assign_manage(client):

--- a/tests/test_assign.py
+++ b/tests/test_assign.py
@@ -136,7 +136,7 @@ def test_assign_edit(client):
 @pytest.mark.parametrize(('name', 'description', 'points', 'edit_date', 'error'),(
     ('testing exam', 'enter discription', '', '2020-06-22T19:10', b'Points are numbers only, check your values.'),
     ('', 'enter description', 90, '2020-06-22T19:10', b'Name is required.'),
-    ('testing exam again', 'description', 10,"", b'Due Date only allows time data, check your values. Please format the time as such using military time. Year-Month-Day Hour:Minute ex. 2020-06-22 19:10')
+    ('testing exam again', 'description', 10,"", b'Please format date &amp; time as')
     ))
 
 def test_edit_errors(client, name, description, points, edit_date, error):
@@ -149,7 +149,7 @@ def test_edit_errors(client, name, description, points, edit_date, error):
     response = client.post('/course/180/session/2/assignment/Edit/1/', data={'edit_name': name,
      'edit_desc': description, 'edit_points': points, 'edit_date': edit_date,
      'edit_type': 'standard'}, follow_redirects = True)
-
+    print(response.data)
     assert error in response.data
 
     rv = logout(client)


### PR DESCRIPTION
- When a teacher creates or edits an assignment, they can now choose from a `<select>` a 'standard' type or an 'upload' type
- When a student views an assignment with the 'upload' type, they will see a 'submit assignment' link
- A few CSS changes